### PR TITLE
Fix Invoices icon rendering undersized at non-default sizes

### DIFF
--- a/packages/obra-icons-react/src/icons/Invoices.tsx
+++ b/packages/obra-icons-react/src/icons/Invoices.tsx
@@ -9,8 +9,8 @@ const Invoices = forwardRef<SVGSVGElement, StrokeIconProps>(
 			<svg
 				ref={ref}
 				width={size}
-				height="25"
-				viewBox="0 0 24 25"
+				height={size}
+				viewBox="0 0 24 24"
 				fill="none"
 				xmlns="http://www.w3.org/2000/svg"
 				{...props}

--- a/packages/obra-icons-svelte/src/icons/Invoices.svelte
+++ b/packages/obra-icons-svelte/src/icons/Invoices.svelte
@@ -8,8 +8,8 @@
 
 <svg
 	width={size}
-	height="25"
-	viewBox="0 0 24 25"
+	height={size}
+	viewBox="0 0 24 24"
 	fill="none"
 	xmlns="http://www.w3.org/2000/svg"
 	class="obra-icon"

--- a/packages/obra-icons-vue/src/icons/Invoices.vue
+++ b/packages/obra-icons-vue/src/icons/Invoices.vue
@@ -13,8 +13,8 @@ export default {
 <template>
 	<svg
 		:width="size"
-		height="25"
-		viewBox="0 0 24 25"
+		:height="size"
+		viewBox="0 0 24 24"
 		fill="none"
 		xmlns="http://www.w3.org/2000/svg"
 		class="obra-icon"

--- a/packages/website/src/lib/svgs/invoices.svg
+++ b/packages/website/src/lib/svgs/invoices.svg
@@ -2,8 +2,8 @@
 
 <svg
 	width="24"
-	height="25"
-	viewBox="0 0 24 25"
+	height="24"
+	viewBox="0 0 24 24"
 	fill="none"
 	xmlns="http://www.w3.org/2000/svg"
 >


### PR DESCRIPTION
## Summary
- `Invoices` was the only icon with a mismatched root `<svg>` box: `height="25"` / `viewBox="0 0 24 25"` while `width` scaled with the `size` prop. The mismatched aspect ratio made the SVG's default `preserveAspectRatio` scale the whole artwork down to fit the fixed height — at `size={44}` it rendered at roughly 24-25px instead.
- Squared up `height`/`viewBox` to match every other icon (`height={size}`, `viewBox="0 0 24 24"`) in `obra-icons-react`, `obra-icons-svelte`, `obra-icons-vue`, and the website's standalone `invoices.svg`.
- Confirmed the artwork itself (rect y=3.5, height=18) sits well within a 24×24 box, so squaring the viewBox doesn't clip anything.

Addresses #103.

## Not included in this PR (follow-ups)
- **npm publish**: `dist/` is gitignored, so this PR only fixes the source. I rebuilt all three packages locally and confirmed the corrected markup lands in `dist` (`obra-icons-react/dist/icons/Invoices.mjs`, `obra-icons-svelte/dist/icons/Invoices.svelte`, `obra-icons-vue/dist/obra-icons-vue.js`), but a new release/publish of `obra-icons-react`/`-svelte`/`-vue` is still needed for existing consumers to actually get the fix.
- **Figma source frame**: the issue notes the generator (`packages/generator`) pulls SVGs straight from Figma with no normalization step, so the source frame for this icon should be checked so a future `import-icons` run doesn't regenerate the broken `24x25` box. I didn't have Figma file access in this environment to check it.
- Left `packages/portfolio-item` (untracked, referenced in the issue as a workaround/verification tool) and an unrelated `pnpm-lock.yaml` diff out of this PR — neither is part of the actual bug fix.

## Test plan
- [x] `pnpm --filter obra-icons-react --filter obra-icons-svelte --filter obra-icons-vue build` — all three build clean
- [x] Verified rebuilt `dist` output for all three packages has `height={size}` / `viewBox="0 0 24 24"`
- [x] Visually confirmed in the website icon grid at size 128 — `invoices` now renders at the same scale as neighboring icons (`bills`, `receipt`, `orders`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)